### PR TITLE
Fixed: Bower.json main tag now points to existing file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "countUp.js-angular1",
-	"main": ["dist/angular-countUp.js"],
+	"main": ["dist/angular-countUp.min.js"],
 	"author": "Jamie Perkins",
 	"dependencies": {
 		"countUp.js": "^1.8.5"


### PR DESCRIPTION
The main tag in the bower.json file points to a non existing file (dist/angular-countUp.js)

Signed-off-by: Ahmed Abdelsamad <ahmed.abdelsamad@live.com>