### PR TITLE
Enabling options watch so that if anything changes it will refresh countUp

### DIFF
--- a/angular-countUp.js
+++ b/angular-countUp.js
@@ -42,15 +42,9 @@
             },
             link: function ($scope, $el, $attrs) {
 
-                var options = {};
-
                 if ($scope.filter) {
                     var filterFunction = createFilterFunction();
-                    options.formattingFn = filterFunction;
-                }
-
-                if ($scope.options) {
-                    angular.extend(options, $scope.options);
+                    $scope.options.formattingFn = filterFunction;
                 }
 
                 var countUp = createCountUp($scope.startVal, $scope.endVal, $scope.decimals, $scope.duration);
@@ -67,7 +61,7 @@
                     };
                 }
 
-                function createCountUp(sta, end, dec, dur) {
+                function createCountUp(sta, end, dec, dur, options) {
                     sta = sta || 0;
                     if (isNaN(sta)) sta = Number(sta.match(/[\d\-\.]+/g).join('')); // strip non-numerical characters
                     end = end || 0;
@@ -126,10 +120,20 @@
                     if (countUp !== null) {
                         countUp.update($scope.endVal);
                     } else {
-                        countUp = createCountUp($scope.startVal, $scope.endVal, $scope.decimals, $scope.duration);
+                        countUp = createCountUp($scope.startVal, $scope.endVal, $scope.decimals, $scope.duration, $scope.options);
                         animate();
                     }
                 });
+
+                $scope.$watch('options', function (newValue, oldValue) {
+
+                    if (newValue === null || newValue === oldValue)
+                        return;
+
+                    // Create new instance every time.
+                    countUp = createCountUp($scope.startVal, $scope.endVal, $scope.decimals, $scope.duration, $scope.options);
+                    animate();
+                }, true); // true for deep watch because options is an object.
             }
         };
     }]);


### PR DESCRIPTION
Hi,

This pull request enables options change watch to trigger an update on the countUp instance if any property of the options object changes.
Use case: We needed to dynamically change the suffix part of the options. For example: if our number was a percentage "97%" and then we needed it to be a number "183.23" we needed to change the options.suffix value and have countUp update.

Additionally we cleaned up the options extend because generally speaking this is when your plugin or module has default options to be replaced with the ones being passed in.
For example:
if you had: var options={ someDefaultValue:5 }; inside of your module/plugin.
you would use extends to override that value.
$scope.options would probably be = { someDefaultValue:6, otherValue:10 }
angular.extend(options, $scope.options);

Please let me know if this makes sense.